### PR TITLE
Updated Provisioning Playbooks with Syntax for PowerMax 2500 and 8500 arrays

### DIFF
--- a/ansible/powermax/provisioning_playbooks/1.Provision_Host.yml
+++ b/ansible/powermax/provisioning_playbooks/1.Provision_Host.yml
@@ -47,6 +47,7 @@
         portgroup_name: "{{ portgroup_name }}"
         state: "present"
         ports:  "{{ port_list }}"
+        port_group_protocol: "SCSI_FC"
         port_state: 'present-in-group'
 
     - name: Create MV "{{ mv_name }}" with existing elements

--- a/ansible/powermax/provisioning_playbooks/2.Change_service_level.yml
+++ b/ansible/powermax/provisioning_playbooks/2.Change_service_level.yml
@@ -47,6 +47,7 @@
         portgroup_name: "{{ portgroup_name }}"
         state: "present"
         ports:  "{{ port_list }}"
+        port_group_protocol: "SCSI_FC"
         port_state: 'present-in-group'
 
     - name: Create MV "{{ mv_name }}" with existing elements

--- a/ansible/powermax/provisioning_playbooks/3.add_volume_to_existing_storagegroup.yml
+++ b/ansible/powermax/provisioning_playbooks/3.add_volume_to_existing_storagegroup.yml
@@ -49,6 +49,7 @@
         portgroup_name: "{{ portgroup_name }}"
         state: "present"
         ports:  "{{ port_list }}"
+        port_group_protocol: "SCSI_FC"
         port_state: 'present-in-group'
 
     - name: Create MV "{{ mv_name }}" with existing elements

--- a/ansible/powermax/provisioning_playbooks/cluster_provisioning_playbooks/1.Provision_Two_Node_Cluster.yml
+++ b/ansible/powermax/provisioning_playbooks/cluster_provisioning_playbooks/1.Provision_Two_Node_Cluster.yml
@@ -77,6 +77,7 @@
         portgroup_name: "{{ portgroup_name }}"
         state: "present"
         ports:  "{{ port_list }}"
+        port_group_protocol: "SCSI_FC"
         port_state: 'present-in-group'
 
     - name: Create MV "{{ mv_name }}" with existing elements

--- a/ansible/powermax/provisioning_playbooks/cluster_provisioning_playbooks/2.Add_Host_To_cluster_make3Node.yml
+++ b/ansible/powermax/provisioning_playbooks/cluster_provisioning_playbooks/2.Add_Host_To_cluster_make3Node.yml
@@ -87,6 +87,7 @@
         portgroup_name: "{{ portgroup_name }}"
         state: "present"
         ports:  "{{ port_list }}"
+        port_group_protocol: "SCSI_FC"
         port_state: 'present-in-group'
 
     - name: Create MV "{{ mv_name }}" with existing elements

--- a/ansible/powermax/provisioning_playbooks/cluster_provisioning_playbooks/3.Remove_Host_from_Cluster.yml
+++ b/ansible/powermax/provisioning_playbooks/cluster_provisioning_playbooks/3.Remove_Host_from_Cluster.yml
@@ -95,6 +95,7 @@
         portgroup_name: "{{ portgroup_name }}"
         state: "present"
         ports:  "{{ port_list }}"
+        port_group_protocol: "SCSI_FC"
         port_state: 'present-in-group'
 
     - name: Create MV "{{ mv_name }}" with existing elements

--- a/ansible/powermax/provisioning_playbooks/cluster_provisioning_playbooks/vars/cluster_storage_details.yml
+++ b/ansible/powermax/provisioning_playbooks/cluster_provisioning_playbooks/vars/cluster_storage_details.yml
@@ -8,10 +8,10 @@ sg_name: Ansible_Cluster_SG
 # Ports to be Used
 
 port_list:
-  - director_id: FA-1D
-    port_id: 8 
-  - director_id: FA-2D
-    port_id: 8
+  - director_id: OR-1C
+    port_id: 1 
+  - director_id: OR-2c
+    port_id: 1
 
 
 # Storage Definition

--- a/ansible/powermax/provisioning_playbooks/vars/host_storage_details.yml
+++ b/ansible/powermax/provisioning_playbooks/vars/host_storage_details.yml
@@ -11,10 +11,10 @@ host_name: Ansible_Host_IG
 # Type, no mixing iSCSI and FC, or FC and NVMeOF
 
 port_list:
-  - director_id: FA-1D
-    port_id: 4 
-  - director_id: FA-2D
-    port_id: 4 
+  - director_id: OR-1C
+    port_id: 1 
+  - director_id: OR-2c
+    port_id: 1 
 
 # Host Initiators ensure colon is removed from input.
 

--- a/ansible/powermax/provisioning_playbooks/vars/host_storage_details.yml
+++ b/ansible/powermax/provisioning_playbooks/vars/host_storage_details.yml
@@ -13,7 +13,7 @@ host_name: Ansible_Host_IG
 port_list:
   - director_id: OR-1C
     port_id: 1 
-  - director_id: OR-2c
+  - director_id: OR-2C
     port_id: 1 
 
 # Host Initiators ensure colon is removed from input.

--- a/ansible/powermax/provisioning_playbooks/vars/host_storage_details2.yml
+++ b/ansible/powermax/provisioning_playbooks/vars/host_storage_details2.yml
@@ -11,10 +11,10 @@ host_name: Ansible_Host_IG
 # Type, no mixing iSCSI and FC, or FC and NVMeOF
 
 port_list:
-  - director_id: FA-1D
-    port_id: 4 
-  - director_id: FA-2D
-    port_id: 4 
+  - director_id: OR-1C
+    port_id: 2 
+  - director_id: OR-2C
+    port_id: 2 
 
 # Host Initiators ensure colon is removed from input.
 

--- a/ansible/powermax/provisioning_playbooks/vars/host_storage_details2.yml
+++ b/ansible/powermax/provisioning_playbooks/vars/host_storage_details2.yml
@@ -12,9 +12,9 @@ host_name: Ansible_Host_IG
 
 port_list:
   - director_id: OR-1C
-    port_id: 2 
+    port_id: 1 
   - director_id: OR-2C
-    port_id: 2 
+    port_id: 1 
 
 # Host Initiators ensure colon is removed from input.
 


### PR DESCRIPTION
Updated playbooks with new syntax for port_group_protocol: "SCSI_FC" and changed Variable files to use OR ports instead for FA ports so playbooks work with 8500 and 2500 arrays.